### PR TITLE
Allow overriding the default alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# Ember-cli-new-version
+# ember-cli-new-version
 ---
 A convention-based version update notifier.
 
 ## Usage
 
 1. Add this add-on as you would any other:
-```bash
-> ember install ember-cli-new-version
-```
+  ```bash
+  > ember install ember-cli-new-version
+  ```
 
 2. Add a version file to your app, eg:
-_./public/VERSION.txt_
+  _./public/VERSION.txt_
 
-```bash
-1.0.0
-```
+  ```bash
+  1.0.0
+  ```
 
 3. Include the component in your view:
-```handlebars
-{{new-version-notifier}}
-```
+  ```handlebars
+  {{new-version-notifier}}
+  ```
 
 **viola**!
 
@@ -27,12 +27,27 @@ _./public/VERSION.txt_
 ----
 * updateInterval - the amount of time, in milliseconds, to wait between version checks **default: 5000**
 * versionFileName - the name of the file on the server to check **default: /VERSION.txt**
-* updateMessage - the message to show to users when update has been detected. There are two tokens allowed in this string: ```{{newVersion}}``` and ```{{oldVersion}}``` which will replaced with their respective values. 
+* updateMessage - the message to show to users when update has been detected. There are two tokens allowed in this string: ```{{newVersion}}``` and ```{{oldVersion}}``` which will replaced with their respective values.
   eg. (and **default**). "This application has been updated from version {{oldVersion}} to {{newVersion}}. Please save any work, then refresh browser to see changes."
 * showReload - _true_ shows a reload button the user can click to refresh. _false_ hides the button. **default: true**
 
 ```handlebars
 {{new-version-notifier updateInterval=<value> versionFileName="<value>" updateMessage="<value>" showReload=true}}
+```
+
+### Custom Notification ###
+
+By default the notification is styled as a Bootstrap Alert. If you want custom layouts or
+to use a different framework, then you can define your own markup for the notification.
+
+```hbs
+{{#new-version-notifier as |version lastVersion reload close|}}
+  <div class="custom-notification">
+    Reload to update to the new version ({{version}}) of this application
+    <button type="button" onclick={{action reload}}>Reload</button>
+    <button type="button" onclick={{action close}}>Close</button>
+  </div>
+{{/new-version-notifier}}
 ```
 
 ## Contributing

--- a/addon/components/ember-cli-new-version.js
+++ b/addon/components/ember-cli-new-version.js
@@ -23,13 +23,21 @@ export default Ember.Component.extend({
       }
 
       Ember.$.ajax(self.get("versionFileName")).then(function(res){
-        if (self.get('version') && self.compareVersions(res, self.get('version')) === -1) {
+        var currentVersion = self.get('version');
+        var newVersion = res && res.trim();
+        
+        if (currentVersion && self.compareVersions(newVersion, currentVersion) === -1) {
           var message = self.get("updateMessage")
-            .replace("{{oldVersion}}",self.get('version'))
-            .replace("{{newVersion}}",res);
-          self.set('message', message);
+            .replace("{{oldVersion}}",currentVersion)
+            .replace("{{newVersion}}",newVersion);
+            
+          self.setProperties({
+            message,
+            lastVersion: currentVersion
+          });
         }
-        self.set('version',res);
+        
+        self.set('version',newVersion);
         self.set('_timeout',setTimeout(function() {
           self.updateVersion();
         },self.get('updateInterval')));
@@ -60,6 +68,10 @@ export default Ember.Component.extend({
   actions: {
     reload() {
       location.reload();
+    },
+    
+    close() {
+      this.set('message', undefined);
     }
   }
 });

--- a/app/templates/components/ember-cli-new-version.hbs
+++ b/app/templates/components/ember-cli-new-version.hbs
@@ -1,5 +1,9 @@
 {{#if message}}
-  <div class='update-notification col-xs-12 alert alert-warning'>
-    {{message}} {{#if showReload}}<a href="" {{action 'reload'}} class='btn btn-default'>Reload</a>{{/if}}
-  </div>
+  {{#if hasBlock}}
+    {{yield version lastVersion (action 'reload') (action 'close')}}
+  {{else}}
+    <div class='update-notification col-xs-12 alert alert-warning'>
+      {{message}} {{#if showReload}}<a href="" {{action 'reload'}} class='btn btn-default'>Reload</a>{{/if}}
+    </div>
+  {{/if}}
 {{/if}}


### PR DESCRIPTION
Can be used like so:

```hbs
{{#new-version-notifier as |version lastVersion reload close|}}
  <div class="custom-notification">
    Reload to update to the new version ({{version}}) of this application
    <button type="button" onclick={{action reload}}>Reload</button>
    <button type="button" onclick={{action close}}>Close</button>
  </div>
{{/new-version-notifier}}
```