### PR TITLE
Fix broccoli-file-creator dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ to use a different framework, then you can define your own markup for the notifi
 {{/new-version-notifier}}
 ```
 
+## Automatic VERSION file creation
+
+You can opt-in to automatically generating a `VERSION.txt` during the build process. Opting-in means you don't need maintain a `/public/VERSION.txt` in your project. Simply add the following to `ember-cli-build.js`:
+
+```
+var app = new EmberApp(defaults, {
+  newVersion: true
+});
+```
+This will result in `dist/VERSION.txt` being created.
+
+To override the version filename:
+
+```
+var app = new EmberApp(defaults, {
+  fileName: 'MY-VERSION.txt'
+});
+```
+This will result in `dist/MY-VERSION.txt` being created. Note that this will also update the default `versionFileName` attribute in the `{{new-version-notifier}}` component.
+
 ## Contributing
 
 * `git clone` this repository

--- a/addon/components/new-version-notifier/component.js
+++ b/addon/components/new-version-notifier/component.js
@@ -13,7 +13,7 @@ export default Ember.Component.extend({
   showReload: true,  
   showReloadButton: Ember.computed.alias("showReload"),
   init: function() {
-    this._super();
+    this._super(...arguments);
     this.updateVersion();
   },
   updateVersion() {

--- a/app/components/ember-cli-new-version.js
+++ b/app/components/ember-cli-new-version.js
@@ -1,3 +1,2 @@
-import Ember from 'ember';
-import NewVersionNotifier from 'ember-cli-new-version/components/new-version-notifier/component';
+import NewVersionNotifier from './new-version-notifier';
 export default NewVersionNotifier;

--- a/app/components/new-version-notifier.js
+++ b/app/components/new-version-notifier.js
@@ -1,5 +1,10 @@
 /*jshint esnext:true */
 
-import Ember from 'ember';
+import config from '../config/environment';
 import NewVersionNotifier from 'ember-cli-new-version/components/new-version-notifier/component';
-export default NewVersionNotifier;
+
+let versionFileName = `/${config.newVersion.fileName}` || '/VERSION.txt';
+
+export default NewVersionNotifier.extend({
+  versionFileName
+});

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,9 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     // Add options here
+    newVersion: {
+      fileName: 'MY-VERSION.txt'
+    }
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -1,6 +1,43 @@
 /* jshint node: true */
 'use strict';
 
+var writeFile = require('broccoli-file-creator');
+
 module.exports = {
-  name: 'ember-cli-new-version'
+  name: 'ember-cli-new-version',
+
+  /*
+  Store config from `ember-cli-build.js`
+   */
+  included: function(app, parentAddon) {
+    this.options = app.options.newVersion || {};
+
+    if (this.options === true) {
+      this.options = { fileName: 'VERSION.txt' };
+    }
+  },
+
+  /*
+  Set options on the environment configuration object so they can
+  be accessed via `import config from '../config/environment';`
+   */
+  config: function(env, baseConfig) {
+    if (this.options && this.options.fileName) {
+      return { newVersion: this.options };
+    }
+  },
+
+  /*
+  Generate version file automatically
+  based on package.json of consuming application.
+   */
+  treeForPublic: function() {
+    var content = this.parent.pkg.version || '';
+    var fileName = this.options.fileName;
+
+    if (this.options.fileName) {
+      this.ui.writeLine('Created ' + fileName);
+      return writeFile(fileName, content);
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "broccoli-file-creator": "^1.1.0",
     "ember-cli": "1.13.13",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -48,6 +47,7 @@
     "new version"
   ],
   "dependencies": {
+    "broccoli-file-creator": "^1.1.0",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
     "broccoli-file-creator": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-new-version",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "A convention based update notification for Ember. With this addon, you can detect a new version and notify the user to refresh the page",
   "directories": {
     "doc": "doc",
@@ -22,6 +22,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "broccoli-file-creator": "^1.1.0",
     "ember-cli": "1.13.13",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -48,7 +49,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "^1.0.1"
+    "ember-cli-htmlbars": "^1.0.1",
+    "broccoli-file-creator": "^1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Has to be in `dependencies`, not `dev-dependencies` so consuming
doesn't complain.