### PR TITLE
Clear timeout on destroy

### DIFF
--- a/addon/components/new-version-notifier/component.js
+++ b/addon/components/new-version-notifier/component.js
@@ -38,18 +38,18 @@ export default Ember.Component.extend({
       Ember.$.ajax(self.get('url'), { cache:false }).then(function(res){
         var currentVersion = self.get('version');
         var newVersion = res && res.trim();
-        
+
         if (currentVersion && self.compareVersions(newVersion, currentVersion) === -1) {
           var message = self.get("updateMessage")
             .replace("{{oldVersion}}",currentVersion)
             .replace("{{newVersion}}",newVersion);
-            
+
           self.setProperties({
             message,
             lastVersion: currentVersion
           });
         }
-        
+
         self.set('version',newVersion);
         self.set('_timeout',setTimeout(function() {
           self.updateVersion();
@@ -78,11 +78,15 @@ export default Ember.Component.extend({
 
     return 0;
   },
+  willDestroy() {
+    this._super(...arguments);
+    clearTimeout(this.get('_timeout'));
+  },
   actions: {
     reload() {
       location.reload();
     },
-    
+
     close() {
       this.set('message', undefined);
     }


### PR DESCRIPTION
Cleans up timing leak by clearing the timeout before destroying the element.