### PR TITLE
using ember-cli-app-version to build the version string

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var writeFile = require('broccoli-file-creator');
+var appVersion  = require('ember-cli-app-version');
 
 module.exports = {
   name: 'ember-cli-new-version',
@@ -22,9 +23,15 @@ module.exports = {
   be accessed via `import config from '../config/environment';`
    */
   config: function(env, baseConfig) {
+    var versionInfo = { APP: {} };
+    appVersion.config.call(this, env, versionInfo);
+
+
     if (this.options && this.options.fileName) {
-      return { newVersion: this.options };
+        versionInfo.newVersion = this.options;
     }
+
+    return versionInfo;
   },
 
   /*
@@ -32,7 +39,7 @@ module.exports = {
   based on package.json of consuming application.
    */
   treeForPublic: function() {
-    var content = this.parent.pkg.version || '';
+    var content = this.config().APP.version;
     var fileName = this.options.fileName;
 
     if (this.options.fileName) {


### PR DESCRIPTION
This is just a quick PR that moves the generation of the app version to use ember-cli-app-version, which is the same thing that ember-self-update uses: https://github.com/xcambar/ember-cli-self-update/blob/master/index.js

This is beneficial because it means you get a sha1 hash of your current revision instead of just relying on the package.json version eg: `0.0.1+062cfd4a`