### PR TITLE
Check For Null / Undefined Update Interval (And Update Readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A convention-based version update notifier.
 
 ### Options ###
 ----
-* `updateInterval` - the amount of time, in milliseconds, to wait between version checks **default: 5000**
+* `updateInterval` - the amount of time, in milliseconds, to wait between version checks **default: 60000**
 * `versionFileName` - the name of the file on the server to check **default: /VERSION.txt**
 * `updateMessage` - the message to show to users when update has been detected. There are two tokens allowed in this string: ```{{newVersion}}``` and ```{{oldVersion}}``` which will replaced with their respective values.
   eg. (and **default**). "This application has been updated from version {{oldVersion}} to {{newVersion}}. Please save any work, then refresh browser to see changes."

--- a/addon/components/new-version-notifier/component.js
+++ b/addon/components/new-version-notifier/component.js
@@ -14,12 +14,13 @@ const {
 let taskRunCounter = 0;
 
 const MAX_COUNT_IN_TESTING = 10;
+const ONE_MINUTE = 60000;
 
 export default Component.extend({
   layout: layout,
 
   tagName          : '',
-  updateInterval   : testing ? 0 : 60000, // One Minute Default
+  updateInterval   : testing ? 0 : ONE_MINUTE,
   versionFileName  : "/VERSION.txt",
   updateMessage    : "This application has been updated from version {{oldVersion}} to {{newVersion}}. Please save any work, then refresh browser to see changes.",
   showReload       : true,
@@ -72,7 +73,9 @@ export default Component.extend({
     } catch (e){
       if (!testing) { throw e; }
     } finally {
-      const updateInterval = this.get('updateInterval');
+      let updateInterval = this.get('updateInterval');
+      if (updateInterval === null || updateInterval === undefined) { updateInterval = ONE_MINUTE }
+        
       yield timeout(updateInterval);
 
       if (testing && ++taskRunCounter > MAX_COUNT_IN_TESTING) { return; }


### PR DESCRIPTION
If `null` or `undefined` are set for `updateInterval` than the HTTP GET to the version endpoint will not pause for anything. This could be dangerous to the API backend with the traffic flood and probably not great for the browser either with all the network cycles.

This PR does two things:
* If `null` or `undefined` are passed, we default to 1 minute.
* Update the documentation regarding the default.