### PR TITLE
use version from ember-cli-app-version when installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ var app = new EmberApp(defaults, {
 ```
 This will result in `dist/MY-VERSION.txt` being created. Note that this will also update the default `versionFileName` attribute in the `{{new-version-notifier}}` component.
 
+### Supports ember-cli-app-version
+
+Since version 1.6.0 this addons is able to use the version string provided by [ember-cli-app-version](https://github.com/ember-cli/ember-cli-app-version).
+
+All you have to do is install `ember-cli-app-version` and - not to change the behavior of existing applications - enable a flag in `ember-cli-build.js`.
+
+Then an update is triggered based on full version strings with build metadata such as `1.0.0-beta-2-e1dffe1`.
+
+```js
+newVersion: {
+  enabled: true,
+  useAppVersion: true
+}
+```
+
 ## Contributing
 
 * `git clone` this repository


### PR DESCRIPTION
This is my attempt to finish https://github.com/sethwebster/ember-cli-new-version/pull/20

I've tried to make sure there are no behavioural changes users must explicitly enable this functionality.

In addition there is no hard dependency on ember-cli-app-version