### PR TITLE
Don't destructure Ember.testing

### DIFF
--- a/addon/components/new-version-notifier/component.js
+++ b/addon/components/new-version-notifier/component.js
@@ -8,7 +8,6 @@ const {
   computed,
   Component,
   get,
-  testing
 } = Ember;
 
 let taskRunCounter = 0;
@@ -20,7 +19,7 @@ export default Component.extend({
   layout: layout,
 
   tagName          : '',
-  updateInterval   : testing ? 0 : ONE_MINUTE,
+  updateInterval   : Ember.testing ? 0 : ONE_MINUTE,
   versionFileName  : "/VERSION.txt",
   updateMessage    : "This application has been updated from version {{oldVersion}} to {{newVersion}}. Please save any work, then refresh browser to see changes.",
   showReload       : true,
@@ -43,7 +42,7 @@ export default Component.extend({
   init () {
     this._super(...arguments);
 
-    if (testing) { taskRunCounter = 0; }
+    if (Ember.testing) { taskRunCounter = 0; }
 
     this.get('updateVersion').perform();
   },
@@ -71,14 +70,14 @@ export default Component.extend({
           this.set('version', newVersion);
         });
     } catch (e){
-      if (!testing) { throw e; }
+      if (!Ember.testing) { throw e; }
     } finally {
       let updateInterval = this.get('updateInterval');
       if (updateInterval === null || updateInterval === undefined) { updateInterval = ONE_MINUTE }
         
       yield timeout(updateInterval);
 
-      if (testing && ++taskRunCounter > MAX_COUNT_IN_TESTING) { return; }
+      if (Ember.testing && ++taskRunCounter > MAX_COUNT_IN_TESTING) { return; }
 
       this.get('updateVersion').perform();
     }

--- a/tests/integration/components/new-version-notifier-test.js
+++ b/tests/integration/components/new-version-notifier-test.js
@@ -35,7 +35,7 @@ test('it works', function (assert) {
     return callCount < 4 ? 'v1.0.' + callCount : 'v1.0.3';
   });
 
-  this.render(hbs`{{new-version-notifier updateInterval=100 version=version lastVersion=lastVersion}}`);
+  this.render(hbs`{{new-version-notifier updateInterval=200 version=version lastVersion=lastVersion}}`);
 
   const done = assert.async(3);
 
@@ -55,7 +55,7 @@ test('it works', function (assert) {
     assert.equal(this.$().text().trim().replace(/\n|\t/, ''), 'This application has been updated from version v1.0.1 to v1.0.2. Please save any work, then refresh browser to see changes. Reload      ×');
 
     done();
-  }, 150);
+  }, 300);
 
   later(() => {
     assert.equal(callCount, 6);
@@ -64,7 +64,7 @@ test('it works', function (assert) {
     assert.equal(this.$().text().trim().replace(/\n|\t/, ''), 'This application has been updated from version v1.0.2 to v1.0.3. Please save any work, then refresh browser to see changes. Reload      ×');
 
     done();
-  }, 650);
+  }, 1150);
 });
 
 test('one version', function (assert) {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,7 @@
 import resolver from './helpers/resolver';
 import {
   setResolver
-} from 'ember-qunit';
+} from '@ember/test-helpers';
 import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);


### PR DESCRIPTION
This primarily fixes #45. I also encountered a lot of flakiness with the primary component test and was able to resolve that just by adjusting the timers a bit. Now it seems to pass reliably on both fast and slow CPUs.

I'm working on some other PRs to hopefully solve some of the other issues. However in doing so I'll probably want to get this addon upgraded to a newer Ember version. Not sure how back you want to support but I'll see how it looks.