### PR TITLE
Log exceptions instead of throwing them

### DIFF
--- a/addon/components/new-version-notifier/component.js
+++ b/addon/components/new-version-notifier/component.js
@@ -1,3 +1,4 @@
+/*eslint no-console: ["error", { allow: ["log"] }] */
 import { getOwner } from '@ember/application';
 import Component from '@ember/component';
 import { get, computed } from '@ember/object';
@@ -78,8 +79,10 @@ export default Component.extend({
 
           this.set('version', newVersion);
         });
-    } catch (e){
-      if (!Ember.testing) { throw e; }
+    } catch (e) {
+      if (!Ember.testing) {
+        console.log(e);
+      }
     } finally {
       let updateInterval = this.get('updateIntervalWithTesting');
       if (updateInterval === null || updateInterval === undefined) { updateInterval = ONE_MINUTE }


### PR DESCRIPTION
When there is a network or other issue fetching the VERSION file we
should just log it. This prevents ugly user messages or busy logging
when users machines go to sleep and stop network traffic.

Fixes #49 

Is this all that is needed? Seems to easy.