### PR TITLE
Add an 'onError' handler

### DIFF
--- a/addon/components/new-version-notifier/component.js
+++ b/addon/components/new-version-notifier/component.js
@@ -24,6 +24,11 @@ export default Component.extend({
   showReload       : true,
   reloadButtonText : "Reload",
   onNewVersion(/* version, lastVersion */) {},
+  onError(e) {
+    if (!Ember.testing) {
+      console.log(e);
+    }
+  },
 
   // internal state:
   lastVersion      : null,
@@ -80,9 +85,7 @@ export default Component.extend({
           this.set('version', newVersion);
         });
     } catch (e) {
-      if (!Ember.testing) {
-        console.log(e);
-      }
+      this.onError(e);
     } finally {
       let updateInterval = this.get('updateIntervalWithTesting');
       if (updateInterval === null || updateInterval === undefined) { updateInterval = ONE_MINUTE }


### PR DESCRIPTION
This add an `onError` hook that can be used to do something if the request fails (it's optional, and by default just contains the existing "on error" logic of logging the error in non-test environments).

(The real-world use case for this is to be able to tell when the endpoint response is a 403, usually meaning the user's session has expired, so we can redirect them back to the login page without the user having to try to perform some action first.)