### PR TITLE
Allow custom version comparison function

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A convention-based version update notifier. Use it to notify users already on th
 * `showReload` - _true_ shows a reload button the user can click to refresh. _false_ hides the button. **default: true**
 * `reloadButtonText` - Sets the text for the default reload button. **default: "Reload"**
 * `onNewVersion(newVersion, oldVersion)` - a closure action that is called whenever a new version is detected. You can use this to track the version status elsewhere in your app (outside the component).
+* `updateNeeded(oldVersion, newVersion)` - a function that is called to check if an update message should be shown.   For example, a function could be passed that only shows a message on major version changes. **default: Always show message on any version change**
 
 ```handlebars
 {{new-version-notifier updateInterval=<value> versionFileName="<value>" updateMessage="<value>" showReload=true}}

--- a/addon/components/new-version-notifier/component.js
+++ b/addon/components/new-version-notifier/component.js
@@ -75,7 +75,7 @@ export default Component.extend({
           const currentVersion = this.get('version');
           const newVersion     = res && res.trim();
 
-          if (currentVersion && newVersion !== currentVersion) {
+          if (this.updateNeeded(currentVersion, newVersion)) {
             const message = this.get('updateMessage')
               .replace('{{oldVersion}}', currentVersion)
               .replace('{{newVersion}}', newVersion);
@@ -104,6 +104,9 @@ export default Component.extend({
     }
   }),
 
+  updateNeeded(currentVersion, newVersion) {
+    return currentVersion && newVersion !== currentVersion;
+  },
 
   actions: {
     reload() {


### PR DESCRIPTION
This allows an `updateNeeded` function to be passed to `new-version-notifier`.

Can be used for example to only show the update message when a major or minor number changes, and not patch number.

```
updateNeeded(currentVersion, newVersion) {
  if (!currentVersion) { return false }

  // Only compare major and minor version number
  let currentV = currentVersion.substr(0, currentVersion.lastIndexOf("."));
  let newV = newVersion.substr(0, newVersion.lastIndexOf("."));

  return newV !== currentV;
}
```