### PR TITLE
allow to set initial delay for first check and disable in fastboot mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A convention-based version update notifier. Use it to notify users already on th
 ### Options ###
 ----
 * `updateInterval` - the amount of time, in milliseconds, to wait between version checks **default: 60000**
+* `firstCheckInterval` - the amount of time, in milliseconds, to wait before the first version check is run after booting the application **default: 0**
 * `versionFileName` - the name of the file on the server to check **default: /VERSION.txt**
 * `updateMessage` - the message to show to users when update has been detected. There are two tokens allowed in this string: ```{{newVersion}}``` and ```{{oldVersion}}``` which will replaced with their respective values.
   eg. (and **default**). "This application has been updated from version {{oldVersion}} to {{newVersion}}. Please save any work, then refresh browser to see changes."
@@ -93,7 +94,7 @@ let app = new EmberApp(defaults, {
   newVersion: {
     enabled: true,
     useAppVersion: true
-  }  
+  }
 });
 ```
 


### PR DESCRIPTION
This PR does two things:

- it prevents to run checks for new versions when the application is run in a fastboot server, which is actually rather useless. Currently it likely will not work reliable on fastboot as we should defer rendering until the request is fulfilled (I though never noticed any warnings regarding this)
- it adds an additional parameter `firstCheckInterval` which delays the first check if a new version is available. Currently when the app launches, a request is made to determine if there is a new version available. This is pointless in scenarios where it is very likely that the client already has the current version (like short cache TTL for the index page, when served from fastboot, when no service worker is present, and/or when the service worker implements a fallback strategy). The default value however keeps the current behaviour (`firstCheckInterval = 0`), so this will PR will not introduce a breaking change