### PR TITLE
[Breaking] Read Version in Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ module.exports = function (environment) {
 * `versionFileName` - the name of the file on the server to check **default: /VERSION.txt**
 * `updateInterval` - the amount of time, in milliseconds, to wait between version checks **default: 60000**
 * `firstCheckInterval` - the amount of time, in milliseconds, to wait before the first version check is run after booting the application **default: 0**
-* `enableInTests` - Shoud the version checking run in test environments? **default: false**
+* `enableInTests` - Should the version checking run in test environments? **default: false**
 * `maxCountInTesting` - How many times to check for a new version in tests. **default: 10**
 
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ module.exports = function (environment) {
       versionFileName: 'VERSION.txt',
       updateInterval: 60000,
       firstCheckInterval: 0,
-      createVersionFileAutomatically: false,
       enableInTests: false,
       maxCountInTesting: 10,    
     },
@@ -58,16 +57,11 @@ module.exports = function (environment) {
 * `firstCheckInterval` - the amount of time, in milliseconds, to wait before the first version check is run after booting the application **default: 0**
 * `enableInTests` - Shoud the version checking run in test environments? **default: false**
 * `maxCountInTesting` - How many times to check for a new version in tests. **default: 10**
-* `createVersionFileAutomatically` - Opt-in to automatically generating a `VERSION.txt` during the build process. Opting-in means you don't need maintain a `/public/VERSION.txt` in your project. Simply add the following to `ember-cli-build.js`:
 
-```js
-let app = new EmberApp(defaults, {
-  newVersion: {
-    enabled: true
-  }
-});
-```
-This will result in `dist/VERSION.txt` being created.
+
+## Automatic Version File Creation ##
+If no `VERSION.txt` file exists it will be automatically generated during the build process 
+with the value of `currentVersion` or the `version` from `package.json`.
 
 ### Supports `ember-cli-app-version`
 
@@ -76,7 +70,6 @@ Since version 4.0.0 this addons will use the version string provided by [ember-c
 All you have to do is install `ember-cli-app-version`.
 
 Then an update is triggered based on full version strings with build metadata such as `1.0.0-beta-2-e1dffe1`.
-
 
 ### Notifier Configuration and Interface ###
 ----

--- a/README.md
+++ b/README.md
@@ -31,23 +31,64 @@ A convention-based version update notifier. Use it to notify users already on th
 
 **voila**!
 
-### Options ###
+## Configuration
+
+To setup, you should first configure the service through `config/environment`:
+
+```javascript
+module.exports = function (environment) {
+  var ENV = {
+    newVersion: {
+      currentVersion: null,
+      versionFileName: 'VERSION.txt',
+      updateInterval: 60000,
+      firstCheckInterval: 0,
+      createVersionFileAutomatically: false,
+      enableInTests: false,
+      maxCountInTesting: 10,    
+    },
+  };
+};
+```
+
 ----
+* `currentVersion` - The current version of the app if not using [Automatic VERSION file creation][#Automatic VERSION file creation] **default: null**
+* `versionFileName` - the name of the file on the server to check **default: /VERSION.txt**
 * `updateInterval` - the amount of time, in milliseconds, to wait between version checks **default: 60000**
 * `firstCheckInterval` - the amount of time, in milliseconds, to wait before the first version check is run after booting the application **default: 0**
-* `versionFileName` - the name of the file on the server to check **default: /VERSION.txt**
+* `enableInTests` - Shoud the version checking run in test environments? **default: false**
+* `maxCountInTesting` - How many times to check for a new version in tests. **default: 10**
+* `createVersionFileAutomatically` - Opt-in to automatically generating a `VERSION.txt` during the build process. Opting-in means you don't need maintain a `/public/VERSION.txt` in your project. Simply add the following to `ember-cli-build.js`:
+
+```js
+let app = new EmberApp(defaults, {
+  newVersion: {
+    enabled: true
+  }
+});
+```
+This will result in `dist/VERSION.txt` being created.
+
+### Supports `ember-cli-app-version`
+
+Since version 4.0.0 this addons will use the version string provided by [ember-cli-app-version](https://github.com/ember-cli/ember-cli-app-version) if no `currentVersion` is configured.
+
+All you have to do is install `ember-cli-app-version`.
+
+Then an update is triggered based on full version strings with build metadata such as `1.0.0-beta-2-e1dffe1`.
+
+
+### Notifier Configuration and Interface ###
+----
 * `updateMessage` - the message to show to users when update has been detected. There are two tokens allowed in this string: `{newVersion}` and `{oldVersion}` which will replaced with their respective values.
   eg. (and **default**). "This application has been updated from version {oldVersion} to {newVersion}. Please save any work, then refresh browser to see changes."
 * `showReload` - _true_ shows a reload button the user can click to refresh. _false_ hides the button. **default: true**
 * `reloadButtonText` - Sets the text for the default reload button. **default: "Reload"**
-* `onNewVersion(newVersion, oldVersion)` - a closure action that is called whenever a new version is detected. You can use this to track the version status elsewhere in your app (outside the component).
-* `updateNeeded(oldVersion, newVersion)` - a function that is called to check if an update message should be shown.   For example, a function could be passed that only shows a message on major version changes. **default: Always show message on any version change**
+
 
 ```handlebars
 <NewVersionNotifier
-  @versionFileName="/version"
   @updateMessage="A new version was released: {newVersion}"
-  @updateInterval={{150000}}
   @showReload={{true}}
 />
 ```
@@ -61,52 +102,10 @@ to use a different framework, then you can define your own markup for the notifi
 <NewVersionNotifier as |version lastVersion reload close|>
   <div class="custom-notification">
     Reload to update to the new version ({{version}}) of this application
-    <button type="button" onclick={{action reload}}>Reload</button>
-    <button type="button" onclick={{action close}}>Close</button>
+    <button type="button" {{on "click" reload}}>Reload</button>
+    <button type="button" {{on "click" close}}>Close</button>
   </div>
 </NewVersionNotifier>
-```
-
-## Automatic VERSION file creation
-
-You can opt-in to automatically generating a `VERSION.txt` during the build process. Opting-in means you don't need maintain a `/public/VERSION.txt` in your project. Simply add the following to `ember-cli-build.js`:
-
-```js
-let app = new EmberApp(defaults, {
-  newVersion: {
-    enabled: true
-  }
-});
-```
-This will result in `dist/VERSION.txt` being created.
-
-To override the version filename:
-
-```js
-let app = new EmberApp(defaults, {
-  newVersion: {
-    enabled: true,
-    fileName: 'MY-VERSION.txt'
-  }
-});
-```
-This will result in `dist/MY-VERSION.txt` being created. Note that this will also update the default `versionFileName` attribute in the `{{new-version-notifier}}` component.
-
-### Supports `ember-cli-app-version`
-
-Since version 1.2.0 this addons is able to use the version string provided by [ember-cli-app-version](https://github.com/ember-cli/ember-cli-app-version).
-
-All you have to do is install `ember-cli-app-version` and enable a flag in `ember-cli-build.js`.
-
-Then an update is triggered based on full version strings with build metadata such as `1.0.0-beta-2-e1dffe1`.
-
-```js
-let app = new EmberApp(defaults, {
-  newVersion: {
-    enabled: true,
-    useAppVersion: true
-  }
-});
 ```
 
 Contributing

--- a/addon/services/new-version.js
+++ b/addon/services/new-version.js
@@ -35,22 +35,13 @@ export default class NewVersionService extends Service {
    * @type Configuration
    */
   get _newVersionConfig() {
-    const defaultConfiguration = {
-      versionFileName: 'VERSION.txt',
-      firstCheckInterval: 0,
-      updateInterval: 60000,
-      enableInTests: false,
-      maxCountInTesting: 10,
-    };
-
-    return Object.assign(defaultConfiguration, this._config.newVersion);
+    return this._config.newVersion;
   }
 
   /**
    * @type {string}
    */
   get currentVersion() {
-    // Users of the addon must set currentVersion.
     return this._newVersionConfig.currentVersion;
   }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,12 +4,7 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function (defaults) {
-  let app = new EmberAddon(defaults, {
-    // Add options here
-    newVersion: {
-      enabled: true,
-    },
-  });
+  let app = new EmberAddon(defaults, {});
 
   /*
     This build file specifies the options for the dummy test app of this

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ module.exports = {
       updateInterval: 60000,
       enableInTests: false,
       maxCountInTesting: 10,
-      createVersionFileAutomatically: false,
     };
 
     baseConfig.newVersion = Object.assign(
@@ -43,13 +42,10 @@ module.exports = {
    * Write version file
    */
   treeForPublic() {
-    const { currentVersion, createVersionFileAutomatically, versionFileName } =
-      this._config;
-    if (currentVersion && createVersionFileAutomatically) {
-      const fileName = versionFileName;
-
-      this.ui.writeLine(`Created ${fileName} with ${currentVersion}`);
-      return writeFile(fileName, currentVersion);
+    const { currentVersion, versionFileName } = this._config;
+    if (currentVersion) {
+      this.ui.writeLine(`Created ${versionFileName} with ${currentVersion}`);
+      return writeFile(versionFileName, currentVersion);
     }
   },
 };

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -26,6 +26,9 @@ module.exports = function (environment) {
     'ember-cli-mirage': {
       enabled: false,
     },
+    newVersion: {
+      createVersionFileAutomatically: true,
+    },
   };
 
   if (environment === 'development') {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -26,9 +26,6 @@ module.exports = function (environment) {
     'ember-cli-mirage': {
       enabled: false,
     },
-    newVersion: {
-      createVersionFileAutomatically: true,
-    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
The move to service based version detection didn't include the automatic ways a version was currently being detected. I've done a few things here:
1) Clarify the documentation for what is configured in `config/environment.js` and what can be passed to the component.
2) [breaking] if no `currentVersion` is detected read it from `ember-cli-app-version`, if `ember-cli-app-version` is not installed then read the `version` in `package.json`. This behavior used to be opt-in, but I think the combination of allowing the value to be set manually and having opted into installing that addon is sufficient, easy to change back though if I'm wrong.
3) [breaking] automatically create `VERSION.txt`. This used to be opt-in, however the easiest way to opt out now is just to manually create a `public/VERSION.txt` in the app. Since `currentVersion` has to be manually set this seems like a good default.

I also moved all of the configuration default setup into the config hook so it wasn't duplicated in the service.

Most of this is personal preference around what I think good defaults are. Since the config is now read in one place and defaults are applied in the build it's trivial to add back in the original opt-in behavior if I'm wrong about good options here. Just let me know.

Fixes #103 