### PR TITLE
Close button not working: add tracking context to ignoredVersions

### DIFF
--- a/addon/services/new-version.js
+++ b/addon/services/new-version.js
@@ -49,7 +49,7 @@ export default class NewVersionService extends Service {
    */
   @tracked latestVersion = undefined;
 
-  ignoredVersions = [];
+  @tracked ignoredVersions = [];
 
   /**
    * Templates can use this attribute to show or hide a proposition to reload the page.


### PR DESCRIPTION
The close button does not close the notification, because the getter relies on the ignoredVersions property, which does not have a tracking context assigned. This PR fixes the close button by adding that tracking context.

fixes #110